### PR TITLE
Adds warning from local health economy formulary

### DIFF
--- a/app/views/pages/reducing.html.haml
+++ b/app/views/pages/reducing.html.haml
@@ -8,10 +8,13 @@
     Reducing ACB Risk
 
   %p
-    The following table has been adapted from Scottish Intercollegiate Guidelines Network (SIGN) Polypharmacy Guidance, March 2015, and shows for each group of medications, which are considered to have a lower or higher risk of Anticholinergic Burden
+    The following table has been adapted from Scottish Intercollegiate Guidelines Network (SIGN) Polypharmacy Guidance, March 2015, and shows for each group of medications, which are considered to have a lower or higher risk of Anticholinergic Burden.
 
   %p
     When consulting the literature, there are discrepancies between the numerical anticholinergic burden assigned to different medications. In the interest of patient safety, we have opted for the higher burden scores in these instances.
+
+  %p
+    Please consider recommendations from your local health economy formulary when making prescribing decisions.
 
   %table.table.table-striped.table-condensed
     %thead


### PR DESCRIPTION
Adds the warning "Please consider recommendations from your local health economy formulary when making prescribing decisions." to Reducing ACB Risk page